### PR TITLE
Update syrlex2mqtt.js

### DIFF
--- a/syrlex2mqtt.js
+++ b/syrlex2mqtt.js
@@ -513,7 +513,7 @@ async function initWebServer() {
 		next();
 	});
 	
-	app.post('/WebServices/SyrConnectLimexWebService.asmx/GetBasicCommands', (req, res) => {
+	app.get('/WebServices/SyrConnectLimexWebService.asmx/GetBasicCommands', (req, res) => {
 		basicCommands(req, res);
 	});
 	app.post('/GetBasicCommands', (req, res) => {


### PR DESCRIPTION
Line 516 - Changed from .post to .get. At least in my case (LEXplus10 TLP0 1.7), the method for the endpoint GetBasicCommands is an GET.