### PR TITLE
Update syrlex2mqtt.js > state_class for total_water_consumption

### DIFF
--- a/syrlex2mqtt.js
+++ b/syrlex2mqtt.js
@@ -211,6 +211,9 @@ async function sendMQTTSensorDiscoveryMessage(mqttclient, mqttDevice, sensorname
         unique_id: mqttDevice.identifier() + "_" + sensorname,
         device: mqttDevice
       };
+  if (sensorname === "total_water_consumption") {
+        payload.state_class = "total_increasing";
+  }
   removeNullProperties(payload);
   await mqttclient.publish(topic, JSON.stringify(payload), {retain: true})
 }


### PR DESCRIPTION
Added `state_class: "total_increasing"` to the `total_water_consumption` sensor to ensure compatibility with Home Assistant's Energy Dashboard (Water Consumption tracking). Without this attribute, the sensor is not recognized as a cumulative water meter.

This change aligns with the Home Assistant documentation: https://www.home-assistant.io/docs/energy/faq/#troubleshooting-missing-entities